### PR TITLE
Fix version format to make it possible to install in newer setuptools

### DIFF
--- a/pygazebo/__init__.py
+++ b/pygazebo/__init__.py
@@ -37,4 +37,4 @@ __all__ = ["connect", "Manager", "Publisher", "Subscriber"]
 
 __author__ = 'Josh Pieper'
 __email__ = 'jjp@pobox.com'
-__version__ = '4.0.0-2019.07'
+__version__ = '4.0.0'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.hexversion < 0x03040000:
 
 setup(
     name='pygazebo',
-    version='4.0.0-2019.07',
+    version='4.0.0',
     description='Python bindings for the Gazebo multi-robot simulator.',
     long_description=readme + '\n\n' + history,
     author='Josh Pieper',


### PR DESCRIPTION
This version works, but cannot be installed properly with error: `setuptools.extern.packaging.version.InvalidVersion: Invalid version: '4.0.0-2019.07'`. I guess the required version format is more strict now? See [PEP-440](https://peps.python.org/pep-0440/).

Simplified version format so it can be installed without errors.